### PR TITLE
Request url not updating after slot server selection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@api-components/api-request",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/api-request",
   "description": "A set of composite components that are used to build an HTTP request editor with the support of the AMF model.",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "license": "Apache-2.0",
   "main": "index.js",
   "module": "index.js",

--- a/src/ApiRequestEditorElement.js
+++ b/src/ApiRequestEditorElement.js
@@ -310,6 +310,7 @@ export class ApiRequestEditorElement extends AmfHelperMixin(EventsTargetMixin(Li
     }
     this._serverValue = value;
     this._updateServer();
+    this.readUrlData();
     this.requestUpdate('serverValue', old);
   }
 

--- a/test/ApiRequestEditorElement.test.js
+++ b/test/ApiRequestEditorElement.test.js
@@ -740,6 +740,26 @@ describe('ApiRequestEditorElement', () => {
           assert.equal(text, 'http://production.domain.com/people');
         });
       });
+
+      describe('slotted servers', () => {
+        let element = /** @type ApiRequestEditorElement */ (null);
+        let amf;
+
+        beforeEach(async () => {
+          element = await customBaseUriSlotFixture();
+          amf = await AmfLoader.load({ compact });
+          element.amf = amf;
+          const op = AmfLoader.lookupOperation(amf, '/people', 'get')
+          element.selected = op['@id'];
+          await aTimeout(0);
+        });
+
+        it('should update api-url-editor value after selecting slotted base uri', async () => {
+          element._serverHandler(new CustomEvent('apiserverchanged', { detail: { value: 'http://customServer.com', type: 'uri' } }));
+          await aTimeout(0);
+          assert.equal(element.shadowRoot.querySelector('api-url-editor').value, 'http://customServer.com/people');
+        });
+      })
     });
   });
 

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -9,7 +9,7 @@ export default {
 			return next();
 		}
 	],
-	testsFinishTimeout: 10000,
+	testsFinishTimeout: 60000,
 	testRunnerHtml: (testFramework) =>
     `<html>
 		<body>

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -9,6 +9,7 @@ export default {
 			return next();
 		}
 	],
+	testsFinishTimeout: 10000,
 	testRunnerHtml: (testFramework) =>
     `<html>
 		<body>

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -9,7 +9,6 @@ export default {
 			return next();
 		}
 	],
-	testsFinishTimeout: 60000,
 	testRunnerHtml: (testFramework) =>
     `<html>
 		<body>


### PR DESCRIPTION
- After server value changes, call `readUrlData` to update the `_apiBaseUri` value correctly