### PR TITLE
Add Content-Type to serialized request if not present

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@api-components/api-request",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/api-request",
   "description": "A set of composite components that are used to build an HTTP request editor with the support of the AMF model.",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "license": "Apache-2.0",
   "main": "index.js",
   "module": "index.js",

--- a/src/ApiRequestEditorElement.d.ts
+++ b/src/ApiRequestEditorElement.d.ts
@@ -155,9 +155,13 @@ export declare class ApiRequestEditorElement extends AmfHelperMixin(EventsTarget
    */
   url: string;
   /**
-   * Current content type.
+   * Current content type as defined by headers.
    */
-  _contentType: string;
+  _headerContentType: string;
+  /**
+   * Current content type as defined by body editor.
+   */
+  _bodyContentType: string;
   /**
    * Computed value of security scheme from selected method.
    */
@@ -479,6 +483,12 @@ export declare class ApiRequestEditorElement extends AmfHelperMixin(EventsTarget
    * Handler for the change dispatched from the server selector.
    */
   _serverHandler(e: CustomEvent): void;
+
+  /**
+   * Given a headers string, if it does not contain a Content-Type header,
+   * set it manually and return the computed headers string.
+   */
+  _ensureContentTypeInHeaders(headersString: string): string
 
   render(): TemplateResult;
 

--- a/test/ApiRequestEditorElement.test.js
+++ b/test/ApiRequestEditorElement.test.js
@@ -688,6 +688,14 @@ describe('ApiRequestEditorElement', () => {
           const result = element.serializeRequest();
           assert.isUndefined(result.payload);
         });
+
+        it('sets Content-Type header if not present but set in component', async () => {
+          const element = await basicFixture();
+          element._headerContentType = 'application/json';
+          element._headers = '';
+          const result = element.serializeRequest();
+          assert.equal(result.headers, 'content-type: application/json');
+        });
       });
 
       describe('_sendHandler()', () => {

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -9,7 +9,7 @@ export default {
 			return next();
 		}
 	],
-	testsFinishTimeout: 4000,
+	testsFinishTimeout: 10000,
 	testRunnerHtml: (testFramework) =>
     `<html>
 		<body>

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -9,6 +9,7 @@ export default {
 			return next();
 		}
 	],
+	testsFinishTimeout: 4000,
 	testRunnerHtml: (testFramework) =>
     `<html>
 		<body>
@@ -29,5 +30,5 @@ export default {
 			<script src="node_modules/codemirror/addon/lint/json-lint.js"></script>
 		  <script type="module" src="${testFramework}"></script>
 		</body>
-	  </html>`
+	  </html>`,
 };

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -9,6 +9,7 @@ export default {
 			return next();
 		}
 	],
+	testsStartTimeout: 20000,
 	testsFinishTimeout: 20000,
 	testRunnerHtml: (testFramework) =>
     `<html>

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -9,6 +9,7 @@ export default {
 			return next();
 		}
 	],
+	browserStartTimeout: 20000,
 	testsStartTimeout: 20000,
 	testsFinishTimeout: 20000,
 	testRunnerHtml: (testFramework) =>

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -9,7 +9,7 @@ export default {
 			return next();
 		}
 	],
-	testsFinishTimeout: 10000,
+	testsFinishTimeout: 20000,
 	testRunnerHtml: (testFramework) =>
     `<html>
 		<body>


### PR DESCRIPTION
When serializing request, if the `Content-Type` header is not present, then add it according to the `contentType` value of the component.