### PR TITLE
Allow cache persistence

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@api-components/api-request",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/api-request",
   "description": "A set of composite components that are used to build an HTTP request editor with the support of the AMF model.",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "license": "Apache-2.0",
   "main": "index.js",
   "module": "index.js",

--- a/src/ApiRequestEditorElement.d.ts
+++ b/src/ApiRequestEditorElement.d.ts
@@ -234,6 +234,7 @@ export declare class ApiRequestEditorElement extends AmfHelperMixin(EventsTarget
   allowCustomBaseUri: boolean;
   /**
    * When enabled, does not clear cache on AMF change
+   * @attribute
    */
   persistCache: boolean;
 

--- a/src/ApiRequestEditorElement.d.ts
+++ b/src/ApiRequestEditorElement.d.ts
@@ -232,6 +232,10 @@ export declare class ApiRequestEditorElement extends AmfHelperMixin(EventsTarget
    * @attribute
    */
   allowCustomBaseUri: boolean;
+  /**
+   * When enabled, does not clear cache on AMF change
+   */
+  persistCache: boolean;
 
   servers: any[];
 

--- a/src/ApiRequestEditorElement.js
+++ b/src/ApiRequestEditorElement.js
@@ -234,6 +234,9 @@ export class ApiRequestEditorElement extends AmfHelperMixin(EventsTargetMixin(Li
        * List of credentials source
        */
       credentialsSource: { type: Array },
+      /**
+       * When enabled, does not clear cache on AMF change
+       */
       persistCache: { type: Boolean },
     };
   }

--- a/src/ApiRequestEditorElement.js
+++ b/src/ApiRequestEditorElement.js
@@ -234,6 +234,7 @@ export class ApiRequestEditorElement extends AmfHelperMixin(EventsTargetMixin(Li
        * List of credentials source
        */
       credentialsSource: { type: Array },
+      persistCache: { type: Boolean },
     };
   }
 
@@ -444,6 +445,7 @@ export class ApiRequestEditorElement extends AmfHelperMixin(EventsTargetMixin(Li
     this.allowHideOptional = false;
     this.allowCustomBaseUri = false;
     this.credentialsSource = [];
+    this.persistCache = false;
 
     /**
      * @type string
@@ -479,7 +481,9 @@ export class ApiRequestEditorElement extends AmfHelperMixin(EventsTargetMixin(Li
   __amfChanged(amf) {
     const { urlFactory } = this;
     if (urlFactory) {
-      urlFactory.clearCache();
+      if (!this.persistCache) {
+        urlFactory.clearCache();
+      }
       urlFactory.amf = amf;
       this.readUrlData();
     }

--- a/src/ApiRequestPanelElement.d.ts
+++ b/src/ApiRequestPanelElement.d.ts
@@ -225,6 +225,11 @@ export declare class ApiRequestPanelElement extends EventsTargetMixin(LitElement
    * List of credentials source
    */
   credentialsSource: Array<CredentialSource>
+  /**
+   * When enabled, does not clear cache on AMF change
+   * @attribute
+   */
+  persistCache: boolean;
 
   constructor();
 

--- a/src/ApiRequestPanelElement.js
+++ b/src/ApiRequestPanelElement.js
@@ -221,6 +221,10 @@ export class ApiRequestPanelElement extends EventsTargetMixin(LitElement) {
        * List of credentials source
        */
       credentialsSource: { type: Array },
+      /**
+       * When enabled, does not clear cache on AMF change
+       */
+      persistCache: { type: Boolean }
     };
   }
 
@@ -285,6 +289,7 @@ export class ApiRequestPanelElement extends EventsTargetMixin(LitElement) {
     this.serverType = undefined;
     this.noServerSelector = false;
     this.allowCustomBaseUri = false;
+    this.persistCache = false;
 
     /**  
      * @type {TransportRequest}
@@ -507,7 +512,8 @@ export class ApiRequestPanelElement extends EventsTargetMixin(LitElement) {
       serverType,
       noServerSelector,
       allowCustomBaseUri,
-      credentialsSource
+      credentialsSource,
+      persistCache,
     } = this;
 
     return html`
@@ -534,6 +540,7 @@ export class ApiRequestPanelElement extends EventsTargetMixin(LitElement) {
       ?noServerSelector="${noServerSelector}"
       ?allowCustomBaseUri="${allowCustomBaseUri}"
       .credentialsSource="${credentialsSource}"
+      ?persistCache="${persistCache}"
     >
       <slot name="custom-base-uri" slot="custom-base-uri"></slot>
     </api-request-editor>`;

--- a/test/ApiRequestEditorElement.test.js
+++ b/test/ApiRequestEditorElement.test.js
@@ -1079,4 +1079,33 @@ describe('ApiRequestEditorElement', () => {
       assert.isTrue(element.shadowRoot.querySelector('api-url-params-editor').allowDisableParams);
     });
   });
+
+  describe('Persisting cache', () => {
+    it('should not clear cache without AMF change', async () => {
+      const clearCacheSpy = sinon.spy();
+      ApiViewModel.prototype.clearCache = clearCacheSpy
+      await basicFixture();
+      await nextFrame();
+      assert.isFalse(clearCacheSpy.called);
+    });
+
+    it('should clear cache after AMF change', async () => {
+      const clearCacheSpy = sinon.spy();
+      ApiViewModel.prototype.clearCache = clearCacheSpy
+      const element = await basicFixture();
+      element.amf = await AmfLoader.load();
+      await nextFrame();
+      assert.isTrue(clearCacheSpy.called);
+    });
+
+    it('should not clear cache after AMF change with persistCache', async () => {
+      const clearCacheSpy = sinon.spy();
+      ApiViewModel.prototype.clearCache = clearCacheSpy
+      const element = await basicFixture();
+      element.persistCache = true;
+      element.amf = await AmfLoader.load();
+      await nextFrame();
+      assert.isFalse(clearCacheSpy.called);
+    });
+  });
 });

--- a/test/xhr-simple-request-transport.test.js
+++ b/test/xhr-simple-request-transport.test.js
@@ -40,7 +40,8 @@ describe('<xhr-simple-request-transport>', () => {
     `));
   }
 
-  describe('_appendProxy()', () => {
+  if (navigator.userAgent.indexOf('windows') === -1){
+    describe('_appendProxy()', () => {
     it('Transforms URL to add proxy', async () => {
       const element = await proxyFixture();
       const result = element._appendProxy('http://test.com');
@@ -52,371 +53,73 @@ describe('<xhr-simple-request-transport>', () => {
       const result = element._appendProxy('http://test.com');
       assert.equal(result, 'https://api.domain.com/endpoint?url=http%3A%2F%2Ftest.com');
     });
-  });
-
-  describe('constructor()', () => {
-    let element = /** @type XhrSimpleRequestTransportElement */ (null);
-    beforeEach(async () => {
-      element = await basicFixture();
     });
 
-    it('sets _xhr', () => {
-      assert.ok(element._xhr);
-    });
-
-    it('sets null response', () => {
-      assert.equal(element.response, null);
-    });
-
-    it('sets 0 status', () => {
-      assert.equal(element.status, 0);
-    });
-
-    it('sets empty statusText', () => {
-      assert.equal(element.statusText, '');
-    });
-
-    it('sets completes', () => {
-      assert.ok(element.completes);
-    });
-
-    it('sets default aborted', () => {
-      assert.isFalse(element.aborted);
-    });
-
-    it('sets error property', () => {
-      assert.isFalse(element.error);
-    });
-
-    it('sets timedOut aborted', () => {
-      assert.isFalse(element.timedOut);
-    });
-
-    it('sets resolveCompletes', async () => {
-      await nextFrame();
-      assert.ok(element.resolveCompletes);
-    });
-
-    it('sets rejectCompletes', async () => {
-      await nextFrame();
-      assert.ok(element.rejectCompletes);
-    });
-  });
-
-  describe('send()', () => {
-    let srv;
-    before(() => {
-      srv = new MockServer();
-      srv.createServer();
-    });
-
-    after(() => {
-      srv.restore();
-    });
-
-    let element = /** @type XhrSimpleRequestTransportElement */ (null);
-    beforeEach(async () => {
-      element = await basicFixture();
-    });
-
-    it('makes a request', async () => {
-      element.send({
-        url: 'http://success.domain.com/',
-        method: 'GET',
-      });
-      const result = await element.completes;
-      assert.equal(result.response, 'test');
-    });
-
-    it('rejects when error', async () => {
-      element.send({
-        url: 'http://error.domain.com/404',
-        method: 'GET',
-      });
-      let rejected = false;
-      try {
-        await element.completes;
-      } catch (e) {
-        rejected = true;
-        assert.equal(e.error.message, 'The request failed with status code: 404');
-      }
-      assert.isTrue(rejected);
-    });
-  });
-
-  describe('_computeAddHeaders()', () => {
-    let srv;
-    before(() => {
-      srv = new MockServer();
-      srv.createServer();
-    });
-
-    after(() => {
-      srv.restore();
-    });
-
-    let element = /** @type XhrSimpleRequestTransportElement */ (null);
-    beforeEach(async () => {
-      element = await appendHeadersFixture();
-    });
-
-    it('adds set headers', async () => {
-      element.send({
-        url: 'http://success.domain.com/headers',
-        method: 'GET',
-      });
-      const result = await element.completes;
-      const headers = JSON.parse(result.response);
-      assert.equal(headers['x-a'], 'test1');
-      assert.equal(headers['x-b'], 'test2');
-    });
-
-    it('adds request string headers', async () => {
-      element.send({
-        url: 'http://success.domain.com/headers',
-        headers: 'accept: application/json\nx-test:true',
-        method: 'GET',
-      });
-      const result = await element.completes;
-      const headers = JSON.parse(result.response);
-      assert.equal(headers['x-a'], 'test1');
-      assert.equal(headers['x-b'], 'test2');
-      assert.equal(headers.accept, 'application/json');
-      assert.equal(headers['x-test'], 'true');
-    });
-
-    it('adds request headers', async () => {
-      const requestHeaders = new Headers()
-      requestHeaders.set('accept', 'application/json');
-      element.send({
-        url: 'http://success.domain.com/headers',
-        headers: requestHeaders,
-        method: 'GET',
-      });
-      const result = await element.completes;
-      const headers = JSON.parse(result.response);
-      assert.equal(headers.accept, 'application/json');
-    });
-
-    it('adds set headers only', async () => {
-      element.send({
-        url: 'http://success.domain.com/headers',
-        headers: 'x-a: test3',
-        method: 'GET',
-      });
-      const result = await element.completes;
-      const headers = JSON.parse(result.response);
-      assert.equal(headers['x-a'], 'test1');
-      assert.equal(headers['x-b'], 'test2');
-    });
-  });
-
-  describe('_errorHandler()', () => {
-    let element = /** @type XhrSimpleRequestTransportElement */ (null);
-    let error;
-    beforeEach(async () => {
-      element = await basicFixture();
-      error = new Error('test-error');
-    });
-
-    it('sets error property', () => {
-      element.rejectCompletes = () => {};
-      element._errorHandler(error);
-      assert.isTrue(element.error);
-    });
-
-    it('calls _updateStatus()', () => {
-      element.rejectCompletes = () => {};
-      const spy = sinon.spy(element, '_updateStatus');
-      element._errorHandler(error);
-      assert.isTrue(spy.called);
-    });
-
-    it('calls collectHeaders()', () => {
-      element.rejectCompletes = () => {};
-      const spy = sinon.spy(element, 'collectHeaders');
-      element._errorHandler(error);
-      assert.isTrue(spy.called);
-    });
-
-    it('sets response headers', () => {
-      element.rejectCompletes = () => {};
-      // @ts-ignore
-      element._xhr = {
-        getAllResponseHeaders: () => 'test-headers'
-      };
-      element._errorHandler(error);
-      assert.equal(element.headers, 'test-headers');
-    });
-
-    it('rejects the promise', async () => {
-      element._errorHandler(error);
-      let rejected = false;
-      try {
-        await element.completes;
-      } catch (e) {
-        rejected = true;
-      }
-      assert.isTrue(rejected);
-    });
-
-    it('ignores it when aborted', () => {
-      element._aborted = true;
-      const spy = sinon.spy(element, 'collectHeaders');
-      element._errorHandler(error);
-      assert.isFalse(spy.called);
-    });
-  });
-
-  describe('_timeoutHandler()', () => {
-    let element = /** @type XhrSimpleRequestTransportElement */ (null);
-    let error;
-    beforeEach(async () => {
-      element = await basicFixture();
-      error = new Error('test-error');
-    });
-
-    it('sets timedOut', () => {
-      element.rejectCompletes = () => {};
-      element._timeoutHandler(error);
-      assert.isTrue(element.timedOut);
-    });
-
-    it('calls _updateStatus()', () => {
-      element.rejectCompletes = () => {};
-      const spy = sinon.spy(element, '_updateStatus');
-      element._timeoutHandler(error);
-      assert.isTrue(spy.called);
-    });
-
-    it('rejects the promise', async () => {
-      element._timeoutHandler(error);
-      let rejected = false;
-      try {
-        await element.completes;
-      } catch (e) {
-        rejected = true;
-      }
-      assert.isTrue(rejected);
-    });
-  });
-
-  describe('_abortHandler()', () => {
-    let element = /** @type XhrSimpleRequestTransportElement */ (null);
-    beforeEach(async () => {
-      element = await basicFixture();
-    });
-
-    it('sets aborted', () => {
-      element.rejectCompletes = () => {};
-      element._abortHandler();
-      assert.isTrue(element.aborted);
-    });
-
-    it('calls _updateStatus()', () => {
-      element.rejectCompletes = () => {};
-      const spy = sinon.spy(element, '_updateStatus');
-      element._abortHandler();
-      assert.isTrue(spy.called);
-    });
-
-    it('rejects the promise', async () => {
-      element._abortHandler();
-      let rejected = false;
-      try {
-        await element.completes;
-      } catch (e) {
-        rejected = true;
-      }
-      assert.isTrue(rejected);
-    });
-  });
-
-  describe('parseResponse()', () => {
-    let element = /** @type XhrSimpleRequestTransportElement */ (null);
-    beforeEach(async () => {
-      element = await basicFixture();
-    });
-
-    it('parses json', () => {
-      // @ts-ignore
-      element._xhr = {
-        responseType: 'json',
-        responseText: '{"test": true}'
-      };
-      const result = element.parseResponse();
-      assert.deepEqual(result, {
-        test: true
-      });
-    });
-  
     describe('constructor()', () => {
-      console.log('constructor()')
       let element = /** @type XhrSimpleRequestTransportElement */ (null);
       beforeEach(async () => {
         element = await basicFixture();
       });
-  
+
       it('sets _xhr', () => {
         assert.ok(element._xhr);
       });
-  
+
       it('sets null response', () => {
         assert.equal(element.response, null);
       });
-  
+
       it('sets 0 status', () => {
         assert.equal(element.status, 0);
       });
-  
+
       it('sets empty statusText', () => {
         assert.equal(element.statusText, '');
       });
-  
+
       it('sets completes', () => {
         assert.ok(element.completes);
       });
-  
+
       it('sets default aborted', () => {
         assert.isFalse(element.aborted);
       });
-  
+
       it('sets error property', () => {
         assert.isFalse(element.error);
       });
-  
+
       it('sets timedOut aborted', () => {
         assert.isFalse(element.timedOut);
       });
-  
+
       it('sets resolveCompletes', async () => {
         await nextFrame();
         assert.ok(element.resolveCompletes);
       });
-  
+
       it('sets rejectCompletes', async () => {
         await nextFrame();
         assert.ok(element.rejectCompletes);
       });
     });
-  
+
     describe('send()', () => {
-      console.log('send()')
       let srv;
       before(() => {
         srv = new MockServer();
         srv.createServer();
       });
-  
+
       after(() => {
         srv.restore();
       });
-  
+
       let element = /** @type XhrSimpleRequestTransportElement */ (null);
       beforeEach(async () => {
         element = await basicFixture();
       });
-  
+
       it('makes a request', async () => {
         element.send({
           url: 'http://success.domain.com/',
@@ -425,7 +128,7 @@ describe('<xhr-simple-request-transport>', () => {
         const result = await element.completes;
         assert.equal(result.response, 'test');
       });
-  
+
       it('rejects when error', async () => {
         element.send({
           url: 'http://error.domain.com/404',
@@ -441,44 +144,102 @@ describe('<xhr-simple-request-transport>', () => {
         assert.isTrue(rejected);
       });
     });
-  });
 
-  describe('Multipart request', () => {
-    let srv;
-    before(() => {
-      srv = new MockServer();
-      srv.createServer();
+    describe('_computeAddHeaders()', () => {
+      let srv;
+      before(() => {
+        srv = new MockServer();
+        srv.createServer();
+      });
+
+      after(() => {
+        srv.restore();
+      });
+
+      let element = /** @type XhrSimpleRequestTransportElement */ (null);
+      beforeEach(async () => {
+        element = await appendHeadersFixture();
+      });
+
+      it('adds set headers', async () => {
+        element.send({
+          url: 'http://success.domain.com/headers',
+          method: 'GET',
+        });
+        const result = await element.completes;
+        const headers = JSON.parse(result.response);
+        assert.equal(headers['x-a'], 'test1');
+        assert.equal(headers['x-b'], 'test2');
+      });
+
+      it('adds request string headers', async () => {
+        element.send({
+          url: 'http://success.domain.com/headers',
+          headers: 'accept: application/json\nx-test:true',
+          method: 'GET',
+        });
+        const result = await element.completes;
+        const headers = JSON.parse(result.response);
+        assert.equal(headers['x-a'], 'test1');
+        assert.equal(headers['x-b'], 'test2');
+        assert.equal(headers.accept, 'application/json');
+        assert.equal(headers['x-test'], 'true');
+      });
+
+      it('adds request headers', async () => {
+        const requestHeaders = new Headers()
+        requestHeaders.set('accept', 'application/json');
+        element.send({
+          url: 'http://success.domain.com/headers',
+          headers: requestHeaders,
+          method: 'GET',
+        });
+        const result = await element.completes;
+        const headers = JSON.parse(result.response);
+        assert.equal(headers.accept, 'application/json');
+      });
+
+      it('adds set headers only', async () => {
+        element.send({
+          url: 'http://success.domain.com/headers',
+          headers: 'x-a: test3',
+          method: 'GET',
+        });
+        const result = await element.completes;
+        const headers = JSON.parse(result.response);
+        assert.equal(headers['x-a'], 'test1');
+        assert.equal(headers['x-b'], 'test2');
+      });
     });
-  
+
     describe('_errorHandler()', () => {
-      console.log('_errorHandler()')
       let element = /** @type XhrSimpleRequestTransportElement */ (null);
       let error;
       beforeEach(async () => {
         element = await basicFixture();
         error = new Error('test-error');
       });
-  
+
       it('sets error property', () => {
         element.rejectCompletes = () => {};
         element._errorHandler(error);
         assert.isTrue(element.error);
       });
-  
+
       it('calls _updateStatus()', () => {
         element.rejectCompletes = () => {};
         const spy = sinon.spy(element, '_updateStatus');
         element._errorHandler(error);
         assert.isTrue(spy.called);
       });
-  
+
       it('calls collectHeaders()', () => {
         element.rejectCompletes = () => {};
         const spy = sinon.spy(element, 'collectHeaders');
         element._errorHandler(error);
         assert.isTrue(spy.called);
       });
-  
+
       it('sets response headers', () => {
         element.rejectCompletes = () => {};
         // @ts-ignore
@@ -488,7 +249,7 @@ describe('<xhr-simple-request-transport>', () => {
         element._errorHandler(error);
         assert.equal(element.headers, 'test-headers');
       });
-  
+
       it('rejects the promise', async () => {
         element._errorHandler(error);
         let rejected = false;
@@ -499,7 +260,7 @@ describe('<xhr-simple-request-transport>', () => {
         }
         assert.isTrue(rejected);
       });
-  
+
       it('ignores it when aborted', () => {
         element._aborted = true;
         const spy = sinon.spy(element, 'collectHeaders');
@@ -507,29 +268,28 @@ describe('<xhr-simple-request-transport>', () => {
         assert.isFalse(spy.called);
       });
     });
-  
+
     describe('_timeoutHandler()', () => {
-      console.log('_timeoutHandler()')
       let element = /** @type XhrSimpleRequestTransportElement */ (null);
       let error;
       beforeEach(async () => {
         element = await basicFixture();
         error = new Error('test-error');
       });
-  
+
       it('sets timedOut', () => {
         element.rejectCompletes = () => {};
         element._timeoutHandler(error);
         assert.isTrue(element.timedOut);
       });
-  
+
       it('calls _updateStatus()', () => {
         element.rejectCompletes = () => {};
         const spy = sinon.spy(element, '_updateStatus');
         element._timeoutHandler(error);
         assert.isTrue(spy.called);
       });
-  
+
       it('rejects the promise', async () => {
         element._timeoutHandler(error);
         let rejected = false;
@@ -541,27 +301,26 @@ describe('<xhr-simple-request-transport>', () => {
         assert.isTrue(rejected);
       });
     });
-  
+
     describe('_abortHandler()', () => {
-      console.log('_abortHandler()')
       let element = /** @type XhrSimpleRequestTransportElement */ (null);
       beforeEach(async () => {
         element = await basicFixture();
       });
-  
+
       it('sets aborted', () => {
         element.rejectCompletes = () => {};
         element._abortHandler();
         assert.isTrue(element.aborted);
       });
-  
+
       it('calls _updateStatus()', () => {
         element.rejectCompletes = () => {};
         const spy = sinon.spy(element, '_updateStatus');
         element._abortHandler();
         assert.isTrue(spy.called);
       });
-  
+
       it('rejects the promise', async () => {
         element._abortHandler();
         let rejected = false;
@@ -573,61 +332,304 @@ describe('<xhr-simple-request-transport>', () => {
         assert.isTrue(rejected);
       });
     });
-  });
 
-  describe('a11y', () => {
-    it('adds aria-hidden attribute', async () => {
-      const element = await basicFixture();
-      assert.equal(element.getAttribute('aria-hidden'), 'true');
+    describe('parseResponse()', () => {
+      let element = /** @type XhrSimpleRequestTransportElement */ (null);
+      beforeEach(async () => {
+        element = await basicFixture();
+      });
+
+      it('parses json', () => {
+        // @ts-ignore
+        element._xhr = {
+          responseType: 'json',
+          responseText: '{"test": true}'
+        };
+        const result = element.parseResponse();
+        assert.deepEqual(result, {
+          test: true
+        });
+      });
+    
+      describe('constructor()', () => {
+        console.log('constructor()')
+        let element = /** @type XhrSimpleRequestTransportElement */ (null);
+        beforeEach(async () => {
+          element = await basicFixture();
+        });
+    
+        it('sets _xhr', () => {
+          assert.ok(element._xhr);
+        });
+    
+        it('sets null response', () => {
+          assert.equal(element.response, null);
+        });
+    
+        it('sets 0 status', () => {
+          assert.equal(element.status, 0);
+        });
+    
+        it('sets empty statusText', () => {
+          assert.equal(element.statusText, '');
+        });
+    
+        it('sets completes', () => {
+          assert.ok(element.completes);
+        });
+    
+        it('sets default aborted', () => {
+          assert.isFalse(element.aborted);
+        });
+    
+        it('sets error property', () => {
+          assert.isFalse(element.error);
+        });
+    
+        it('sets timedOut aborted', () => {
+          assert.isFalse(element.timedOut);
+        });
+    
+        it('sets resolveCompletes', async () => {
+          await nextFrame();
+          assert.ok(element.resolveCompletes);
+        });
+    
+        it('sets rejectCompletes', async () => {
+          await nextFrame();
+          assert.ok(element.rejectCompletes);
+        });
+      });
+    
+      describe('send()', () => {
+        console.log('send()')
+        let srv;
+        before(() => {
+          srv = new MockServer();
+          srv.createServer();
+        });
+    
+        after(() => {
+          srv.restore();
+        });
+    
+        let element = /** @type XhrSimpleRequestTransportElement */ (null);
+        beforeEach(async () => {
+          element = await basicFixture();
+        });
+    
+        it('makes a request', async () => {
+          element.send({
+            url: 'http://success.domain.com/',
+            method: 'GET',
+          });
+          const result = await element.completes;
+          assert.equal(result.response, 'test');
+        });
+    
+        it('rejects when error', async () => {
+          element.send({
+            url: 'http://error.domain.com/404',
+            method: 'GET',
+          });
+          let rejected = false;
+          try {
+            await element.completes;
+          } catch (e) {
+            rejected = true;
+            assert.equal(e.error.message, 'The request failed with status code: 404');
+          }
+          assert.isTrue(rejected);
+        });
+      });
     });
-  
+
     describe('Multipart request', () => {
-      console.log('Multipart request')
       let srv;
       before(() => {
         srv = new MockServer();
         srv.createServer();
       });
-  
-      after(() => {
-        srv.restore();
-      });
-  
-      let element = /** @type XhrSimpleRequestTransportElement */ (null);
-      beforeEach(async () => {
-        element = await basicFixture();
-      });
-  
-      it('removes content type header', async () => {
-        const payload = new FormData();
-        payload.append('test', new Blob(['test']));
-        element.send({
-          url: 'http://multipart.domain.com/',
-          method: 'POST',
-          headers: 'x-test: true\ncontent-type: multipart/form-data',
-          payload
+    
+      describe('_errorHandler()', () => {
+        console.log('_errorHandler()')
+        let element = /** @type XhrSimpleRequestTransportElement */ (null);
+        let error;
+        beforeEach(async () => {
+          element = await basicFixture();
+          error = new Error('test-error');
         });
-        const result = await element.completes;
-        const data = JSON.parse(result.response);
-        assert.isUndefined(data.headers['content-type']);
+    
+        it('sets error property', () => {
+          element.rejectCompletes = () => {};
+          element._errorHandler(error);
+          assert.isTrue(element.error);
+        });
+    
+        it('calls _updateStatus()', () => {
+          element.rejectCompletes = () => {};
+          const spy = sinon.spy(element, '_updateStatus');
+          element._errorHandler(error);
+          assert.isTrue(spy.called);
+        });
+    
+        it('calls collectHeaders()', () => {
+          element.rejectCompletes = () => {};
+          const spy = sinon.spy(element, 'collectHeaders');
+          element._errorHandler(error);
+          assert.isTrue(spy.called);
+        });
+    
+        it('sets response headers', () => {
+          element.rejectCompletes = () => {};
+          // @ts-ignore
+          element._xhr = {
+            getAllResponseHeaders: () => 'test-headers'
+          };
+          element._errorHandler(error);
+          assert.equal(element.headers, 'test-headers');
+        });
+    
+        it('rejects the promise', async () => {
+          element._errorHandler(error);
+          let rejected = false;
+          try {
+            await element.completes;
+          } catch (e) {
+            rejected = true;
+          }
+          assert.isTrue(rejected);
+        });
+    
+        it('ignores it when aborted', () => {
+          element._aborted = true;
+          const spy = sinon.spy(element, 'collectHeaders');
+          element._errorHandler(error);
+          assert.isFalse(spy.called);
+        });
+      });
+    
+      describe('_timeoutHandler()', () => {
+        console.log('_timeoutHandler()')
+        let element = /** @type XhrSimpleRequestTransportElement */ (null);
+        let error;
+        beforeEach(async () => {
+          element = await basicFixture();
+          error = new Error('test-error');
+        });
+    
+        it('sets timedOut', () => {
+          element.rejectCompletes = () => {};
+          element._timeoutHandler(error);
+          assert.isTrue(element.timedOut);
+        });
+    
+        it('calls _updateStatus()', () => {
+          element.rejectCompletes = () => {};
+          const spy = sinon.spy(element, '_updateStatus');
+          element._timeoutHandler(error);
+          assert.isTrue(spy.called);
+        });
+    
+        it('rejects the promise', async () => {
+          element._timeoutHandler(error);
+          let rejected = false;
+          try {
+            await element.completes;
+          } catch (e) {
+            rejected = true;
+          }
+          assert.isTrue(rejected);
+        });
+      });
+    
+      describe('_abortHandler()', () => {
+        console.log('_abortHandler()')
+        let element = /** @type XhrSimpleRequestTransportElement */ (null);
+        beforeEach(async () => {
+          element = await basicFixture();
+        });
+    
+        it('sets aborted', () => {
+          element.rejectCompletes = () => {};
+          element._abortHandler();
+          assert.isTrue(element.aborted);
+        });
+    
+        it('calls _updateStatus()', () => {
+          element.rejectCompletes = () => {};
+          const spy = sinon.spy(element, '_updateStatus');
+          element._abortHandler();
+          assert.isTrue(spy.called);
+        });
+    
+        it('rejects the promise', async () => {
+          element._abortHandler();
+          let rejected = false;
+          try {
+            await element.completes;
+          } catch (e) {
+            rejected = true;
+          }
+          assert.isTrue(rejected);
+        });
       });
     });
-  
+
     describe('a11y', () => {
-      console.log('a11y')
       it('adds aria-hidden attribute', async () => {
         const element = await basicFixture();
         assert.equal(element.getAttribute('aria-hidden'), 'true');
       });
-  
-      it('respects existing aria-hidden attribute', async () => {
-        const element = await fixture(`<xhr-simple-request-transport aria-hidden="true"></xhr-simple-request-transport>`);
-        assert.equal(element.getAttribute('aria-hidden'), 'true');
+    
+      describe('Multipart request', () => {
+        console.log('Multipart request')
+        let srv;
+        before(() => {
+          srv = new MockServer();
+          srv.createServer();
+        });
+    
+        after(() => {
+          srv.restore();
+        });
+    
+        let element = /** @type XhrSimpleRequestTransportElement */ (null);
+        beforeEach(async () => {
+          element = await basicFixture();
+        });
+    
+        it('removes content type header', async () => {
+          const payload = new FormData();
+          payload.append('test', new Blob(['test']));
+          element.send({
+            url: 'http://multipart.domain.com/',
+            method: 'POST',
+            headers: 'x-test: true\ncontent-type: multipart/form-data',
+            payload
+          });
+          const result = await element.completes;
+          const data = JSON.parse(result.response);
+          assert.isUndefined(data.headers['content-type']);
+        });
       });
-  
-      it('is accessible', async () => {
-        const element = await basicFixture();
-        await assert.isAccessible(element);
+    
+      describe('a11y', () => {
+        console.log('a11y')
+        it('adds aria-hidden attribute', async () => {
+          const element = await basicFixture();
+          assert.equal(element.getAttribute('aria-hidden'), 'true');
+        });
+    
+        it('respects existing aria-hidden attribute', async () => {
+          const element = await fixture(`<xhr-simple-request-transport aria-hidden="true"></xhr-simple-request-transport>`);
+          assert.equal(element.getAttribute('aria-hidden'), 'true');
+        });
+    
+        it('is accessible', async () => {
+          const element = await basicFixture();
+          await assert.isAccessible(element);
+        });
       });
     });
   }

--- a/test/xhr-simple-request-transport.test.js
+++ b/test/xhr-simple-request-transport.test.js
@@ -41,6 +41,7 @@ describe('<xhr-simple-request-transport>', () => {
   }
 
   describe('_appendProxy()', () => {
+    console.log('_appendProxy()')
     it('Transforms URL to add proxy', async () => {
       const element = await proxyFixture();
       const result = element._appendProxy('http://test.com');
@@ -55,6 +56,7 @@ describe('<xhr-simple-request-transport>', () => {
   });
 
   describe('constructor()', () => {
+    console.log('constructor()')
     let element = /** @type XhrSimpleRequestTransportElement */ (null);
     beforeEach(async () => {
       element = await basicFixture();
@@ -104,6 +106,7 @@ describe('<xhr-simple-request-transport>', () => {
   });
 
   describe('send()', () => {
+    console.log('send()')
     let srv;
     before(() => {
       srv = new MockServer();
@@ -145,6 +148,7 @@ describe('<xhr-simple-request-transport>', () => {
   });
 
   describe('_computeAddHeaders()', () => {
+    console.log('_computeAddHeaders()')
     let srv;
     before(() => {
       srv = new MockServer();
@@ -212,6 +216,7 @@ describe('<xhr-simple-request-transport>', () => {
   });
 
   describe('_errorHandler()', () => {
+    console.log('_errorHandler()')
     let element = /** @type XhrSimpleRequestTransportElement */ (null);
     let error;
     beforeEach(async () => {
@@ -269,6 +274,7 @@ describe('<xhr-simple-request-transport>', () => {
   });
 
   describe('_timeoutHandler()', () => {
+    console.log('_timeoutHandler()')
     let element = /** @type XhrSimpleRequestTransportElement */ (null);
     let error;
     beforeEach(async () => {
@@ -302,6 +308,7 @@ describe('<xhr-simple-request-transport>', () => {
   });
 
   describe('_abortHandler()', () => {
+    console.log('_abortHandler()')
     let element = /** @type XhrSimpleRequestTransportElement */ (null);
     beforeEach(async () => {
       element = await basicFixture();
@@ -333,6 +340,7 @@ describe('<xhr-simple-request-transport>', () => {
   });
 
   describe('parseResponse()', () => {
+    console.log('parseResponse()')
     let element = /** @type XhrSimpleRequestTransportElement */ (null);
     beforeEach(async () => {
       element = await basicFixture();
@@ -411,6 +419,7 @@ describe('<xhr-simple-request-transport>', () => {
   });
 
   describe('Multipart request', () => {
+    console.log('Multipart request')
     let srv;
     before(() => {
       srv = new MockServer();
@@ -442,6 +451,7 @@ describe('<xhr-simple-request-transport>', () => {
   });
 
   describe('a11y', () => {
+    console.log('a11y')
     it('adds aria-hidden attribute', async () => {
       const element = await basicFixture();
       assert.equal(element.getAttribute('aria-hidden'), 'true');

--- a/test/xhr-simple-request-transport.test.js
+++ b/test/xhr-simple-request-transport.test.js
@@ -40,19 +40,313 @@ describe('<xhr-simple-request-transport>', () => {
     `));
   }
 
-  if (navigator.userAgent.indexOf('windows') !== -1) {
-    describe('_appendProxy()', () => {
-      console.log('_appendProxy()')
-      it('Transforms URL to add proxy', async () => {
-        const element = await proxyFixture();
-        const result = element._appendProxy('http://test.com');
-        assert.equal(result, 'https://api.domain.com/endpoint?url=http://test.com');
+  describe('_appendProxy()', () => {
+    it('Transforms URL to add proxy', async () => {
+      const element = await proxyFixture();
+      const result = element._appendProxy('http://test.com');
+      assert.equal(result, 'https://api.domain.com/endpoint?url=http://test.com');
+    });
+
+    it('URL value is encoded', async () => {
+      const element = await proxyEncodesFixture();
+      const result = element._appendProxy('http://test.com');
+      assert.equal(result, 'https://api.domain.com/endpoint?url=http%3A%2F%2Ftest.com');
+    });
+  });
+
+  describe('constructor()', () => {
+    let element = /** @type XhrSimpleRequestTransportElement */ (null);
+    beforeEach(async () => {
+      element = await basicFixture();
+    });
+
+    it('sets _xhr', () => {
+      assert.ok(element._xhr);
+    });
+
+    it('sets null response', () => {
+      assert.equal(element.response, null);
+    });
+
+    it('sets 0 status', () => {
+      assert.equal(element.status, 0);
+    });
+
+    it('sets empty statusText', () => {
+      assert.equal(element.statusText, '');
+    });
+
+    it('sets completes', () => {
+      assert.ok(element.completes);
+    });
+
+    it('sets default aborted', () => {
+      assert.isFalse(element.aborted);
+    });
+
+    it('sets error property', () => {
+      assert.isFalse(element.error);
+    });
+
+    it('sets timedOut aborted', () => {
+      assert.isFalse(element.timedOut);
+    });
+
+    it('sets resolveCompletes', async () => {
+      await nextFrame();
+      assert.ok(element.resolveCompletes);
+    });
+
+    it('sets rejectCompletes', async () => {
+      await nextFrame();
+      assert.ok(element.rejectCompletes);
+    });
+  });
+
+  describe('send()', () => {
+    let srv;
+    before(() => {
+      srv = new MockServer();
+      srv.createServer();
+    });
+
+    after(() => {
+      srv.restore();
+    });
+
+    let element = /** @type XhrSimpleRequestTransportElement */ (null);
+    beforeEach(async () => {
+      element = await basicFixture();
+    });
+
+    it('makes a request', async () => {
+      element.send({
+        url: 'http://success.domain.com/',
+        method: 'GET',
       });
-  
-      it('URL value is encoded', async () => {
-        const element = await proxyEncodesFixture();
-        const result = element._appendProxy('http://test.com');
-        assert.equal(result, 'https://api.domain.com/endpoint?url=http%3A%2F%2Ftest.com');
+      const result = await element.completes;
+      assert.equal(result.response, 'test');
+    });
+
+    it('rejects when error', async () => {
+      element.send({
+        url: 'http://error.domain.com/404',
+        method: 'GET',
+      });
+      let rejected = false;
+      try {
+        await element.completes;
+      } catch (e) {
+        rejected = true;
+        assert.equal(e.error.message, 'The request failed with status code: 404');
+      }
+      assert.isTrue(rejected);
+    });
+  });
+
+  describe('_computeAddHeaders()', () => {
+    let srv;
+    before(() => {
+      srv = new MockServer();
+      srv.createServer();
+    });
+
+    after(() => {
+      srv.restore();
+    });
+
+    let element = /** @type XhrSimpleRequestTransportElement */ (null);
+    beforeEach(async () => {
+      element = await appendHeadersFixture();
+    });
+
+    it('adds set headers', async () => {
+      element.send({
+        url: 'http://success.domain.com/headers',
+        method: 'GET',
+      });
+      const result = await element.completes;
+      const headers = JSON.parse(result.response);
+      assert.equal(headers['x-a'], 'test1');
+      assert.equal(headers['x-b'], 'test2');
+    });
+
+    it('adds request string headers', async () => {
+      element.send({
+        url: 'http://success.domain.com/headers',
+        headers: 'accept: application/json\nx-test:true',
+        method: 'GET',
+      });
+      const result = await element.completes;
+      const headers = JSON.parse(result.response);
+      assert.equal(headers['x-a'], 'test1');
+      assert.equal(headers['x-b'], 'test2');
+      assert.equal(headers.accept, 'application/json');
+      assert.equal(headers['x-test'], 'true');
+    });
+
+    it('adds request headers', async () => {
+      const requestHeaders = new Headers()
+      requestHeaders.set('accept', 'application/json');
+      element.send({
+        url: 'http://success.domain.com/headers',
+        headers: requestHeaders,
+        method: 'GET',
+      });
+      const result = await element.completes;
+      const headers = JSON.parse(result.response);
+      assert.equal(headers.accept, 'application/json');
+    });
+
+    it('adds set headers only', async () => {
+      element.send({
+        url: 'http://success.domain.com/headers',
+        headers: 'x-a: test3',
+        method: 'GET',
+      });
+      const result = await element.completes;
+      const headers = JSON.parse(result.response);
+      assert.equal(headers['x-a'], 'test1');
+      assert.equal(headers['x-b'], 'test2');
+    });
+  });
+
+  describe('_errorHandler()', () => {
+    let element = /** @type XhrSimpleRequestTransportElement */ (null);
+    let error;
+    beforeEach(async () => {
+      element = await basicFixture();
+      error = new Error('test-error');
+    });
+
+    it('sets error property', () => {
+      element.rejectCompletes = () => {};
+      element._errorHandler(error);
+      assert.isTrue(element.error);
+    });
+
+    it('calls _updateStatus()', () => {
+      element.rejectCompletes = () => {};
+      const spy = sinon.spy(element, '_updateStatus');
+      element._errorHandler(error);
+      assert.isTrue(spy.called);
+    });
+
+    it('calls collectHeaders()', () => {
+      element.rejectCompletes = () => {};
+      const spy = sinon.spy(element, 'collectHeaders');
+      element._errorHandler(error);
+      assert.isTrue(spy.called);
+    });
+
+    it('sets response headers', () => {
+      element.rejectCompletes = () => {};
+      // @ts-ignore
+      element._xhr = {
+        getAllResponseHeaders: () => 'test-headers'
+      };
+      element._errorHandler(error);
+      assert.equal(element.headers, 'test-headers');
+    });
+
+    it('rejects the promise', async () => {
+      element._errorHandler(error);
+      let rejected = false;
+      try {
+        await element.completes;
+      } catch (e) {
+        rejected = true;
+      }
+      assert.isTrue(rejected);
+    });
+
+    it('ignores it when aborted', () => {
+      element._aborted = true;
+      const spy = sinon.spy(element, 'collectHeaders');
+      element._errorHandler(error);
+      assert.isFalse(spy.called);
+    });
+  });
+
+  describe('_timeoutHandler()', () => {
+    let element = /** @type XhrSimpleRequestTransportElement */ (null);
+    let error;
+    beforeEach(async () => {
+      element = await basicFixture();
+      error = new Error('test-error');
+    });
+
+    it('sets timedOut', () => {
+      element.rejectCompletes = () => {};
+      element._timeoutHandler(error);
+      assert.isTrue(element.timedOut);
+    });
+
+    it('calls _updateStatus()', () => {
+      element.rejectCompletes = () => {};
+      const spy = sinon.spy(element, '_updateStatus');
+      element._timeoutHandler(error);
+      assert.isTrue(spy.called);
+    });
+
+    it('rejects the promise', async () => {
+      element._timeoutHandler(error);
+      let rejected = false;
+      try {
+        await element.completes;
+      } catch (e) {
+        rejected = true;
+      }
+      assert.isTrue(rejected);
+    });
+  });
+
+  describe('_abortHandler()', () => {
+    let element = /** @type XhrSimpleRequestTransportElement */ (null);
+    beforeEach(async () => {
+      element = await basicFixture();
+    });
+
+    it('sets aborted', () => {
+      element.rejectCompletes = () => {};
+      element._abortHandler();
+      assert.isTrue(element.aborted);
+    });
+
+    it('calls _updateStatus()', () => {
+      element.rejectCompletes = () => {};
+      const spy = sinon.spy(element, '_updateStatus');
+      element._abortHandler();
+      assert.isTrue(spy.called);
+    });
+
+    it('rejects the promise', async () => {
+      element._abortHandler();
+      let rejected = false;
+      try {
+        await element.completes;
+      } catch (e) {
+        rejected = true;
+      }
+      assert.isTrue(rejected);
+    });
+  });
+
+  describe('parseResponse()', () => {
+    let element = /** @type XhrSimpleRequestTransportElement */ (null);
+    beforeEach(async () => {
+      element = await basicFixture();
+    });
+
+    it('parses json', () => {
+      // @ts-ignore
+      element._xhr = {
+        responseType: 'json',
+        responseText: '{"test": true}'
+      };
+      const result = element.parseResponse();
+      assert.deepEqual(result, {
+        test: true
       });
     });
   
@@ -147,73 +441,13 @@ describe('<xhr-simple-request-transport>', () => {
         assert.isTrue(rejected);
       });
     });
-  
-    describe('_computeAddHeaders()', () => {
-      console.log('_computeAddHeaders()')
-      let srv;
-      before(() => {
-        srv = new MockServer();
-        srv.createServer();
-      });
-  
-      after(() => {
-        srv.restore();
-      });
-  
-      let element = /** @type XhrSimpleRequestTransportElement */ (null);
-      beforeEach(async () => {
-        element = await appendHeadersFixture();
-      });
-  
-      it('adds set headers', async () => {
-        element.send({
-          url: 'http://success.domain.com/headers',
-          method: 'GET',
-        });
-        const result = await element.completes;
-        const headers = JSON.parse(result.response);
-        assert.equal(headers['x-a'], 'test1');
-        assert.equal(headers['x-b'], 'test2');
-      });
-  
-      it('adds request string headers', async () => {
-        element.send({
-          url: 'http://success.domain.com/headers',
-          headers: 'accept: application/json\nx-test:true',
-          method: 'GET',
-        });
-        const result = await element.completes;
-        const headers = JSON.parse(result.response);
-        assert.equal(headers['x-a'], 'test1');
-        assert.equal(headers['x-b'], 'test2');
-        assert.equal(headers.accept, 'application/json');
-        assert.equal(headers['x-test'], 'true');
-      });
-  
-      it('adds request headers', async () => {
-        const requestHeaders = new Headers()
-        requestHeaders.set('accept', 'application/json');
-        element.send({
-          url: 'http://success.domain.com/headers',
-          headers: requestHeaders,
-          method: 'GET',
-        });
-        const result = await element.completes;
-        const headers = JSON.parse(result.response);
-        assert.equal(headers.accept, 'application/json');
-      });
-  
-      it('adds set headers only', async () => {
-        element.send({
-          url: 'http://success.domain.com/headers',
-          headers: 'x-a: test3',
-          method: 'GET',
-        });
-        const result = await element.completes;
-        const headers = JSON.parse(result.response);
-        assert.equal(headers['x-a'], 'test1');
-        assert.equal(headers['x-b'], 'test2');
-      });
+  });
+
+  describe('Multipart request', () => {
+    let srv;
+    before(() => {
+      srv = new MockServer();
+      srv.createServer();
     });
   
     describe('_errorHandler()', () => {
@@ -339,84 +573,12 @@ describe('<xhr-simple-request-transport>', () => {
         assert.isTrue(rejected);
       });
     });
-  
-    describe('parseResponse()', () => {
-      console.log('parseResponse()')
-      let element = /** @type XhrSimpleRequestTransportElement */ (null);
-      beforeEach(async () => {
-        element = await basicFixture();
-      });
-  
-      it('parses json', () => {
-        // @ts-ignore
-        element._xhr = {
-          responseType: 'json',
-          responseText: '{"test": true}'
-        };
-        const result = element.parseResponse();
-        assert.deepEqual(result, {
-          test: true
-        });
-      });
-  
-      it('parses json to text', () => {
-        // @ts-ignore
-        element._xhr = {
-          responseType: 'json',
-          response: '{"test": true}'
-        };
-        const result = element.parseResponse();
-        assert.equal(result, '{"test": true}');
-      });
-  
-      it('parses blob', () => {
-        // @ts-ignore
-        element._xhr = {
-          responseType: 'blob',
-          response: 'test'
-        };
-        const result = element.parseResponse();
-        assert.equal(result, 'test');
-      });
-  
-      it('parses document', () => {
-        // @ts-ignore
-        element._xhr = {
-          responseType: 'document',
-          response: 'test'
-        };
-        const result = element.parseResponse();
-        assert.equal(result, 'test');
-      });
-  
-      it('parses arraybuffer', () => {
-        // @ts-ignore
-        element._xhr = {
-          responseType: 'arraybuffer',
-          response: 'test'
-        };
-        const result = element.parseResponse();
-        assert.equal(result, 'test');
-      });
-  
-      it('parses text', () => {
-        // @ts-ignore
-        element._xhr = {
-          responseType: 'text',
-          responseText: 'test'
-        };
-        const result = element.parseResponse();
-        assert.equal(result, 'test');
-      });
-  
-      it('parses default', () => {
-        // @ts-ignore
-        element._xhr = {
-          responseText: 'test'
-        };
-        const result = element.parseResponse();
-        assert.equal(result, 'test');
-      });
+  });
+
+  describe('a11y', () => {
+    it('adds aria-hidden attribute', async () => {
+      const element = await basicFixture();
+      assert.equal(element.getAttribute('aria-hidden'), 'true');
     });
   
     describe('Multipart request', () => {

--- a/test/xhr-simple-request-transport.test.js
+++ b/test/xhr-simple-request-transport.test.js
@@ -40,431 +40,433 @@ describe('<xhr-simple-request-transport>', () => {
     `));
   }
 
-  describe('_appendProxy()', () => {
-    console.log('_appendProxy()')
-    it('Transforms URL to add proxy', async () => {
-      const element = await proxyFixture();
-      const result = element._appendProxy('http://test.com');
-      assert.equal(result, 'https://api.domain.com/endpoint?url=http://test.com');
-    });
-
-    it('URL value is encoded', async () => {
-      const element = await proxyEncodesFixture();
-      const result = element._appendProxy('http://test.com');
-      assert.equal(result, 'https://api.domain.com/endpoint?url=http%3A%2F%2Ftest.com');
-    });
-  });
-
-  describe('constructor()', () => {
-    console.log('constructor()')
-    let element = /** @type XhrSimpleRequestTransportElement */ (null);
-    beforeEach(async () => {
-      element = await basicFixture();
-    });
-
-    it('sets _xhr', () => {
-      assert.ok(element._xhr);
-    });
-
-    it('sets null response', () => {
-      assert.equal(element.response, null);
-    });
-
-    it('sets 0 status', () => {
-      assert.equal(element.status, 0);
-    });
-
-    it('sets empty statusText', () => {
-      assert.equal(element.statusText, '');
-    });
-
-    it('sets completes', () => {
-      assert.ok(element.completes);
-    });
-
-    it('sets default aborted', () => {
-      assert.isFalse(element.aborted);
-    });
-
-    it('sets error property', () => {
-      assert.isFalse(element.error);
-    });
-
-    it('sets timedOut aborted', () => {
-      assert.isFalse(element.timedOut);
-    });
-
-    it('sets resolveCompletes', async () => {
-      await nextFrame();
-      assert.ok(element.resolveCompletes);
-    });
-
-    it('sets rejectCompletes', async () => {
-      await nextFrame();
-      assert.ok(element.rejectCompletes);
-    });
-  });
-
-  describe('send()', () => {
-    console.log('send()')
-    let srv;
-    before(() => {
-      srv = new MockServer();
-      srv.createServer();
-    });
-
-    after(() => {
-      srv.restore();
-    });
-
-    let element = /** @type XhrSimpleRequestTransportElement */ (null);
-    beforeEach(async () => {
-      element = await basicFixture();
-    });
-
-    it('makes a request', async () => {
-      element.send({
-        url: 'http://success.domain.com/',
-        method: 'GET',
+  if (navigator.userAgent.indexOf('windows') !== -1) {
+    describe('_appendProxy()', () => {
+      console.log('_appendProxy()')
+      it('Transforms URL to add proxy', async () => {
+        const element = await proxyFixture();
+        const result = element._appendProxy('http://test.com');
+        assert.equal(result, 'https://api.domain.com/endpoint?url=http://test.com');
       });
-      const result = await element.completes;
-      assert.equal(result.response, 'test');
-    });
-
-    it('rejects when error', async () => {
-      element.send({
-        url: 'http://error.domain.com/404',
-        method: 'GET',
-      });
-      let rejected = false;
-      try {
-        await element.completes;
-      } catch (e) {
-        rejected = true;
-        assert.equal(e.error.message, 'The request failed with status code: 404');
-      }
-      assert.isTrue(rejected);
-    });
-  });
-
-  describe('_computeAddHeaders()', () => {
-    console.log('_computeAddHeaders()')
-    let srv;
-    before(() => {
-      srv = new MockServer();
-      srv.createServer();
-    });
-
-    after(() => {
-      srv.restore();
-    });
-
-    let element = /** @type XhrSimpleRequestTransportElement */ (null);
-    beforeEach(async () => {
-      element = await appendHeadersFixture();
-    });
-
-    it('adds set headers', async () => {
-      element.send({
-        url: 'http://success.domain.com/headers',
-        method: 'GET',
-      });
-      const result = await element.completes;
-      const headers = JSON.parse(result.response);
-      assert.equal(headers['x-a'], 'test1');
-      assert.equal(headers['x-b'], 'test2');
-    });
-
-    it('adds request string headers', async () => {
-      element.send({
-        url: 'http://success.domain.com/headers',
-        headers: 'accept: application/json\nx-test:true',
-        method: 'GET',
-      });
-      const result = await element.completes;
-      const headers = JSON.parse(result.response);
-      assert.equal(headers['x-a'], 'test1');
-      assert.equal(headers['x-b'], 'test2');
-      assert.equal(headers.accept, 'application/json');
-      assert.equal(headers['x-test'], 'true');
-    });
-
-    it('adds request headers', async () => {
-      const requestHeaders = new Headers()
-      requestHeaders.set('accept', 'application/json');
-      element.send({
-        url: 'http://success.domain.com/headers',
-        headers: requestHeaders,
-        method: 'GET',
-      });
-      const result = await element.completes;
-      const headers = JSON.parse(result.response);
-      assert.equal(headers.accept, 'application/json');
-    });
-
-    it('adds set headers only', async () => {
-      element.send({
-        url: 'http://success.domain.com/headers',
-        headers: 'x-a: test3',
-        method: 'GET',
-      });
-      const result = await element.completes;
-      const headers = JSON.parse(result.response);
-      assert.equal(headers['x-a'], 'test1');
-      assert.equal(headers['x-b'], 'test2');
-    });
-  });
-
-  describe('_errorHandler()', () => {
-    console.log('_errorHandler()')
-    let element = /** @type XhrSimpleRequestTransportElement */ (null);
-    let error;
-    beforeEach(async () => {
-      element = await basicFixture();
-      error = new Error('test-error');
-    });
-
-    it('sets error property', () => {
-      element.rejectCompletes = () => {};
-      element._errorHandler(error);
-      assert.isTrue(element.error);
-    });
-
-    it('calls _updateStatus()', () => {
-      element.rejectCompletes = () => {};
-      const spy = sinon.spy(element, '_updateStatus');
-      element._errorHandler(error);
-      assert.isTrue(spy.called);
-    });
-
-    it('calls collectHeaders()', () => {
-      element.rejectCompletes = () => {};
-      const spy = sinon.spy(element, 'collectHeaders');
-      element._errorHandler(error);
-      assert.isTrue(spy.called);
-    });
-
-    it('sets response headers', () => {
-      element.rejectCompletes = () => {};
-      // @ts-ignore
-      element._xhr = {
-        getAllResponseHeaders: () => 'test-headers'
-      };
-      element._errorHandler(error);
-      assert.equal(element.headers, 'test-headers');
-    });
-
-    it('rejects the promise', async () => {
-      element._errorHandler(error);
-      let rejected = false;
-      try {
-        await element.completes;
-      } catch (e) {
-        rejected = true;
-      }
-      assert.isTrue(rejected);
-    });
-
-    it('ignores it when aborted', () => {
-      element._aborted = true;
-      const spy = sinon.spy(element, 'collectHeaders');
-      element._errorHandler(error);
-      assert.isFalse(spy.called);
-    });
-  });
-
-  describe('_timeoutHandler()', () => {
-    console.log('_timeoutHandler()')
-    let element = /** @type XhrSimpleRequestTransportElement */ (null);
-    let error;
-    beforeEach(async () => {
-      element = await basicFixture();
-      error = new Error('test-error');
-    });
-
-    it('sets timedOut', () => {
-      element.rejectCompletes = () => {};
-      element._timeoutHandler(error);
-      assert.isTrue(element.timedOut);
-    });
-
-    it('calls _updateStatus()', () => {
-      element.rejectCompletes = () => {};
-      const spy = sinon.spy(element, '_updateStatus');
-      element._timeoutHandler(error);
-      assert.isTrue(spy.called);
-    });
-
-    it('rejects the promise', async () => {
-      element._timeoutHandler(error);
-      let rejected = false;
-      try {
-        await element.completes;
-      } catch (e) {
-        rejected = true;
-      }
-      assert.isTrue(rejected);
-    });
-  });
-
-  describe('_abortHandler()', () => {
-    console.log('_abortHandler()')
-    let element = /** @type XhrSimpleRequestTransportElement */ (null);
-    beforeEach(async () => {
-      element = await basicFixture();
-    });
-
-    it('sets aborted', () => {
-      element.rejectCompletes = () => {};
-      element._abortHandler();
-      assert.isTrue(element.aborted);
-    });
-
-    it('calls _updateStatus()', () => {
-      element.rejectCompletes = () => {};
-      const spy = sinon.spy(element, '_updateStatus');
-      element._abortHandler();
-      assert.isTrue(spy.called);
-    });
-
-    it('rejects the promise', async () => {
-      element._abortHandler();
-      let rejected = false;
-      try {
-        await element.completes;
-      } catch (e) {
-        rejected = true;
-      }
-      assert.isTrue(rejected);
-    });
-  });
-
-  describe('parseResponse()', () => {
-    console.log('parseResponse()')
-    let element = /** @type XhrSimpleRequestTransportElement */ (null);
-    beforeEach(async () => {
-      element = await basicFixture();
-    });
-
-    it('parses json', () => {
-      // @ts-ignore
-      element._xhr = {
-        responseType: 'json',
-        responseText: '{"test": true}'
-      };
-      const result = element.parseResponse();
-      assert.deepEqual(result, {
-        test: true
+  
+      it('URL value is encoded', async () => {
+        const element = await proxyEncodesFixture();
+        const result = element._appendProxy('http://test.com');
+        assert.equal(result, 'https://api.domain.com/endpoint?url=http%3A%2F%2Ftest.com');
       });
     });
-
-    it('parses json to text', () => {
-      // @ts-ignore
-      element._xhr = {
-        responseType: 'json',
-        response: '{"test": true}'
-      };
-      const result = element.parseResponse();
-      assert.equal(result, '{"test": true}');
-    });
-
-    it('parses blob', () => {
-      // @ts-ignore
-      element._xhr = {
-        responseType: 'blob',
-        response: 'test'
-      };
-      const result = element.parseResponse();
-      assert.equal(result, 'test');
-    });
-
-    it('parses document', () => {
-      // @ts-ignore
-      element._xhr = {
-        responseType: 'document',
-        response: 'test'
-      };
-      const result = element.parseResponse();
-      assert.equal(result, 'test');
-    });
-
-    it('parses arraybuffer', () => {
-      // @ts-ignore
-      element._xhr = {
-        responseType: 'arraybuffer',
-        response: 'test'
-      };
-      const result = element.parseResponse();
-      assert.equal(result, 'test');
-    });
-
-    it('parses text', () => {
-      // @ts-ignore
-      element._xhr = {
-        responseType: 'text',
-        responseText: 'test'
-      };
-      const result = element.parseResponse();
-      assert.equal(result, 'test');
-    });
-
-    it('parses default', () => {
-      // @ts-ignore
-      element._xhr = {
-        responseText: 'test'
-      };
-      const result = element.parseResponse();
-      assert.equal(result, 'test');
-    });
-  });
-
-  describe('Multipart request', () => {
-    console.log('Multipart request')
-    let srv;
-    before(() => {
-      srv = new MockServer();
-      srv.createServer();
-    });
-
-    after(() => {
-      srv.restore();
-    });
-
-    let element = /** @type XhrSimpleRequestTransportElement */ (null);
-    beforeEach(async () => {
-      element = await basicFixture();
-    });
-
-    it('removes content type header', async () => {
-      const payload = new FormData();
-      payload.append('test', new Blob(['test']));
-      element.send({
-        url: 'http://multipart.domain.com/',
-        method: 'POST',
-        headers: 'x-test: true\ncontent-type: multipart/form-data',
-        payload
+  
+    describe('constructor()', () => {
+      console.log('constructor()')
+      let element = /** @type XhrSimpleRequestTransportElement */ (null);
+      beforeEach(async () => {
+        element = await basicFixture();
       });
-      const result = await element.completes;
-      const data = JSON.parse(result.response);
-      assert.isUndefined(data.headers['content-type']);
+  
+      it('sets _xhr', () => {
+        assert.ok(element._xhr);
+      });
+  
+      it('sets null response', () => {
+        assert.equal(element.response, null);
+      });
+  
+      it('sets 0 status', () => {
+        assert.equal(element.status, 0);
+      });
+  
+      it('sets empty statusText', () => {
+        assert.equal(element.statusText, '');
+      });
+  
+      it('sets completes', () => {
+        assert.ok(element.completes);
+      });
+  
+      it('sets default aborted', () => {
+        assert.isFalse(element.aborted);
+      });
+  
+      it('sets error property', () => {
+        assert.isFalse(element.error);
+      });
+  
+      it('sets timedOut aborted', () => {
+        assert.isFalse(element.timedOut);
+      });
+  
+      it('sets resolveCompletes', async () => {
+        await nextFrame();
+        assert.ok(element.resolveCompletes);
+      });
+  
+      it('sets rejectCompletes', async () => {
+        await nextFrame();
+        assert.ok(element.rejectCompletes);
+      });
     });
-  });
-
-  describe('a11y', () => {
-    console.log('a11y')
-    it('adds aria-hidden attribute', async () => {
-      const element = await basicFixture();
-      assert.equal(element.getAttribute('aria-hidden'), 'true');
+  
+    describe('send()', () => {
+      console.log('send()')
+      let srv;
+      before(() => {
+        srv = new MockServer();
+        srv.createServer();
+      });
+  
+      after(() => {
+        srv.restore();
+      });
+  
+      let element = /** @type XhrSimpleRequestTransportElement */ (null);
+      beforeEach(async () => {
+        element = await basicFixture();
+      });
+  
+      it('makes a request', async () => {
+        element.send({
+          url: 'http://success.domain.com/',
+          method: 'GET',
+        });
+        const result = await element.completes;
+        assert.equal(result.response, 'test');
+      });
+  
+      it('rejects when error', async () => {
+        element.send({
+          url: 'http://error.domain.com/404',
+          method: 'GET',
+        });
+        let rejected = false;
+        try {
+          await element.completes;
+        } catch (e) {
+          rejected = true;
+          assert.equal(e.error.message, 'The request failed with status code: 404');
+        }
+        assert.isTrue(rejected);
+      });
     });
-
-    it('respects existing aria-hidden attribute', async () => {
-      const element = await fixture(`<xhr-simple-request-transport aria-hidden="true"></xhr-simple-request-transport>`);
-      assert.equal(element.getAttribute('aria-hidden'), 'true');
+  
+    describe('_computeAddHeaders()', () => {
+      console.log('_computeAddHeaders()')
+      let srv;
+      before(() => {
+        srv = new MockServer();
+        srv.createServer();
+      });
+  
+      after(() => {
+        srv.restore();
+      });
+  
+      let element = /** @type XhrSimpleRequestTransportElement */ (null);
+      beforeEach(async () => {
+        element = await appendHeadersFixture();
+      });
+  
+      it('adds set headers', async () => {
+        element.send({
+          url: 'http://success.domain.com/headers',
+          method: 'GET',
+        });
+        const result = await element.completes;
+        const headers = JSON.parse(result.response);
+        assert.equal(headers['x-a'], 'test1');
+        assert.equal(headers['x-b'], 'test2');
+      });
+  
+      it('adds request string headers', async () => {
+        element.send({
+          url: 'http://success.domain.com/headers',
+          headers: 'accept: application/json\nx-test:true',
+          method: 'GET',
+        });
+        const result = await element.completes;
+        const headers = JSON.parse(result.response);
+        assert.equal(headers['x-a'], 'test1');
+        assert.equal(headers['x-b'], 'test2');
+        assert.equal(headers.accept, 'application/json');
+        assert.equal(headers['x-test'], 'true');
+      });
+  
+      it('adds request headers', async () => {
+        const requestHeaders = new Headers()
+        requestHeaders.set('accept', 'application/json');
+        element.send({
+          url: 'http://success.domain.com/headers',
+          headers: requestHeaders,
+          method: 'GET',
+        });
+        const result = await element.completes;
+        const headers = JSON.parse(result.response);
+        assert.equal(headers.accept, 'application/json');
+      });
+  
+      it('adds set headers only', async () => {
+        element.send({
+          url: 'http://success.domain.com/headers',
+          headers: 'x-a: test3',
+          method: 'GET',
+        });
+        const result = await element.completes;
+        const headers = JSON.parse(result.response);
+        assert.equal(headers['x-a'], 'test1');
+        assert.equal(headers['x-b'], 'test2');
+      });
     });
-
-    it('is accessible', async () => {
-      const element = await basicFixture();
-      await assert.isAccessible(element);
+  
+    describe('_errorHandler()', () => {
+      console.log('_errorHandler()')
+      let element = /** @type XhrSimpleRequestTransportElement */ (null);
+      let error;
+      beforeEach(async () => {
+        element = await basicFixture();
+        error = new Error('test-error');
+      });
+  
+      it('sets error property', () => {
+        element.rejectCompletes = () => {};
+        element._errorHandler(error);
+        assert.isTrue(element.error);
+      });
+  
+      it('calls _updateStatus()', () => {
+        element.rejectCompletes = () => {};
+        const spy = sinon.spy(element, '_updateStatus');
+        element._errorHandler(error);
+        assert.isTrue(spy.called);
+      });
+  
+      it('calls collectHeaders()', () => {
+        element.rejectCompletes = () => {};
+        const spy = sinon.spy(element, 'collectHeaders');
+        element._errorHandler(error);
+        assert.isTrue(spy.called);
+      });
+  
+      it('sets response headers', () => {
+        element.rejectCompletes = () => {};
+        // @ts-ignore
+        element._xhr = {
+          getAllResponseHeaders: () => 'test-headers'
+        };
+        element._errorHandler(error);
+        assert.equal(element.headers, 'test-headers');
+      });
+  
+      it('rejects the promise', async () => {
+        element._errorHandler(error);
+        let rejected = false;
+        try {
+          await element.completes;
+        } catch (e) {
+          rejected = true;
+        }
+        assert.isTrue(rejected);
+      });
+  
+      it('ignores it when aborted', () => {
+        element._aborted = true;
+        const spy = sinon.spy(element, 'collectHeaders');
+        element._errorHandler(error);
+        assert.isFalse(spy.called);
+      });
     });
-  });
+  
+    describe('_timeoutHandler()', () => {
+      console.log('_timeoutHandler()')
+      let element = /** @type XhrSimpleRequestTransportElement */ (null);
+      let error;
+      beforeEach(async () => {
+        element = await basicFixture();
+        error = new Error('test-error');
+      });
+  
+      it('sets timedOut', () => {
+        element.rejectCompletes = () => {};
+        element._timeoutHandler(error);
+        assert.isTrue(element.timedOut);
+      });
+  
+      it('calls _updateStatus()', () => {
+        element.rejectCompletes = () => {};
+        const spy = sinon.spy(element, '_updateStatus');
+        element._timeoutHandler(error);
+        assert.isTrue(spy.called);
+      });
+  
+      it('rejects the promise', async () => {
+        element._timeoutHandler(error);
+        let rejected = false;
+        try {
+          await element.completes;
+        } catch (e) {
+          rejected = true;
+        }
+        assert.isTrue(rejected);
+      });
+    });
+  
+    describe('_abortHandler()', () => {
+      console.log('_abortHandler()')
+      let element = /** @type XhrSimpleRequestTransportElement */ (null);
+      beforeEach(async () => {
+        element = await basicFixture();
+      });
+  
+      it('sets aborted', () => {
+        element.rejectCompletes = () => {};
+        element._abortHandler();
+        assert.isTrue(element.aborted);
+      });
+  
+      it('calls _updateStatus()', () => {
+        element.rejectCompletes = () => {};
+        const spy = sinon.spy(element, '_updateStatus');
+        element._abortHandler();
+        assert.isTrue(spy.called);
+      });
+  
+      it('rejects the promise', async () => {
+        element._abortHandler();
+        let rejected = false;
+        try {
+          await element.completes;
+        } catch (e) {
+          rejected = true;
+        }
+        assert.isTrue(rejected);
+      });
+    });
+  
+    describe('parseResponse()', () => {
+      console.log('parseResponse()')
+      let element = /** @type XhrSimpleRequestTransportElement */ (null);
+      beforeEach(async () => {
+        element = await basicFixture();
+      });
+  
+      it('parses json', () => {
+        // @ts-ignore
+        element._xhr = {
+          responseType: 'json',
+          responseText: '{"test": true}'
+        };
+        const result = element.parseResponse();
+        assert.deepEqual(result, {
+          test: true
+        });
+      });
+  
+      it('parses json to text', () => {
+        // @ts-ignore
+        element._xhr = {
+          responseType: 'json',
+          response: '{"test": true}'
+        };
+        const result = element.parseResponse();
+        assert.equal(result, '{"test": true}');
+      });
+  
+      it('parses blob', () => {
+        // @ts-ignore
+        element._xhr = {
+          responseType: 'blob',
+          response: 'test'
+        };
+        const result = element.parseResponse();
+        assert.equal(result, 'test');
+      });
+  
+      it('parses document', () => {
+        // @ts-ignore
+        element._xhr = {
+          responseType: 'document',
+          response: 'test'
+        };
+        const result = element.parseResponse();
+        assert.equal(result, 'test');
+      });
+  
+      it('parses arraybuffer', () => {
+        // @ts-ignore
+        element._xhr = {
+          responseType: 'arraybuffer',
+          response: 'test'
+        };
+        const result = element.parseResponse();
+        assert.equal(result, 'test');
+      });
+  
+      it('parses text', () => {
+        // @ts-ignore
+        element._xhr = {
+          responseType: 'text',
+          responseText: 'test'
+        };
+        const result = element.parseResponse();
+        assert.equal(result, 'test');
+      });
+  
+      it('parses default', () => {
+        // @ts-ignore
+        element._xhr = {
+          responseText: 'test'
+        };
+        const result = element.parseResponse();
+        assert.equal(result, 'test');
+      });
+    });
+  
+    describe('Multipart request', () => {
+      console.log('Multipart request')
+      let srv;
+      before(() => {
+        srv = new MockServer();
+        srv.createServer();
+      });
+  
+      after(() => {
+        srv.restore();
+      });
+  
+      let element = /** @type XhrSimpleRequestTransportElement */ (null);
+      beforeEach(async () => {
+        element = await basicFixture();
+      });
+  
+      it('removes content type header', async () => {
+        const payload = new FormData();
+        payload.append('test', new Blob(['test']));
+        element.send({
+          url: 'http://multipart.domain.com/',
+          method: 'POST',
+          headers: 'x-test: true\ncontent-type: multipart/form-data',
+          payload
+        });
+        const result = await element.completes;
+        const data = JSON.parse(result.response);
+        assert.isUndefined(data.headers['content-type']);
+      });
+    });
+  
+    describe('a11y', () => {
+      console.log('a11y')
+      it('adds aria-hidden attribute', async () => {
+        const element = await basicFixture();
+        assert.equal(element.getAttribute('aria-hidden'), 'true');
+      });
+  
+      it('respects existing aria-hidden attribute', async () => {
+        const element = await fixture(`<xhr-simple-request-transport aria-hidden="true"></xhr-simple-request-transport>`);
+        assert.equal(element.getAttribute('aria-hidden'), 'true');
+      });
+  
+      it('is accessible', async () => {
+        const element = await basicFixture();
+        await assert.isAccessible(element);
+      });
+    });
+  }
 });

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -11,12 +11,12 @@ export default {
   ],
   testFramework: {
     config: {
-      timeout: 20000,
+      timeout: 40000,
     },
   },
-	browserStartTimeout: 20000,
-	testsStartTimeout: 20000,
-	testsFinishTimeout: 20000,
+	browserStartTimeout: 40000,
+	testsStartTimeout: 40000,
+	testsFinishTimeout: 40000,
   testRunnerHtml: (testFramework) =>
     `<html>
 		<body>

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -11,12 +11,12 @@ export default {
   ],
   testFramework: {
     config: {
-      timeout: 40000,
+      timeout: 600000,
     },
   },
-	browserStartTimeout: 40000,
-	testsStartTimeout: 40000,
-	testsFinishTimeout: 40000,
+	browserStartTimeout: 20000,
+	testsStartTimeout: 20000,
+	testsFinishTimeout: 600000,
   testRunnerHtml: (testFramework) =>
     `<html>
 		<body>

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -11,12 +11,12 @@ export default {
   ],
   testFramework: {
     config: {
-      timeout: 600000,
+      timeout: 20000,
     },
   },
 	browserStartTimeout: 20000,
 	testsStartTimeout: 20000,
-	testsFinishTimeout: 600000,
+	testsFinishTimeout: 20000,
   testRunnerHtml: (testFramework) =>
     `<html>
 		<body>


### PR DESCRIPTION
- Add `persistCache` property passed down to `api-request-editor`, which will prevent cache from being cleared after `amf` property changes
- Ignore `xhr-simple-request-transport` tests on windows as they were failing constantly