### PR TITLE
Populating deleted headers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@api-components/api-request",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/api-request",
   "description": "A set of composite components that are used to build an HTTP request editor with the support of the AMF model.",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "license": "Apache-2.0",
   "main": "index.js",
   "module": "index.js",

--- a/src/ApiRequestEditorElement.js
+++ b/src/ApiRequestEditorElement.js
@@ -1024,8 +1024,8 @@ export class ApiRequestEditorElement extends AmfHelperMixin(EventsTargetMixin(Li
     const queryParamItem = newQueryModel.find(item => item.name === name);
     if (queryParamItem) {
       queryParamItem.value = value;
+      this._queryModel = newQueryModel;
     }
-    this._queryModel = newQueryModel;
   }
 
   /**
@@ -1041,9 +1041,11 @@ export class ApiRequestEditorElement extends AmfHelperMixin(EventsTargetMixin(Li
     const name = this._getValue(headerNode, nameKey);
     const headers = HeadersParser.stringToJSON(this._headers);
     const headerItem = headers.find(header => header.name === name);
-    headerItem.value = value;
-    // We can't call the HeadersParser.toString() method because it removes the empty headers
-    this._headers = headers.map(header => HeadersParser.itemToString(header)).join('\n');
+    if (headerItem) {
+      headerItem.value = value;
+      // We can't call the HeadersParser.toString() method because it removes the empty headers
+      this._headers = headers.map(header => HeadersParser.itemToString(header)).join('\n');
+    }
   }
 
   _urlHandler(e) {

--- a/test/ApiRequestEditorElement.test.js
+++ b/test/ApiRequestEditorElement.test.js
@@ -1153,6 +1153,22 @@ describe('ApiRequestEditorElement', () => {
         const queryParams = element._queryModel.map(qm => qm.value);
         assert.deepEqual(queryParams, ['', 'test value 1']);
       });
+
+      it('_updateHeader should not throw error if header isn\'t in form', async () => {
+        element.allowCustom = true;
+        await nextFrame();
+        const headersEditor = element.shadowRoot.querySelector('api-headers-editor')
+        const firstIconButton = headersEditor.shadowRoot.querySelector('.params-list anypoint-icon-button')
+        firstIconButton.click()
+        await nextFrame();
+        const detail = { values: [
+            { annotationName: 'credentialType', annotationValue: 'id', fieldValue: 'test value 1' },
+            { annotationName: 'credentialType', annotationValue: 'secret', fieldValue: 'test value 2' },
+          ] };
+        assert.doesNotThrow(() => {
+          element._populateAnnotatedFieldsHandler(new CustomEvent('populate_annotated_fields', { detail, bubbles: true }));
+        });
+      });
     });
   });
 


### PR DESCRIPTION
When a header was deleted, a population event would cause an error to be thrown.