### PR TITLE
Don't remove headers for FormData paylods

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@api-components/api-request",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@api-components/api-request",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@advanced-rest-client/arc-events": "^0.2.13",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/api-request",
   "description": "A set of composite components that are used to build an HTTP request editor with the support of the AMF model.",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "license": "Apache-2.0",
   "main": "index.js",
   "module": "index.js",

--- a/src/ApiRequestEditorElement.js
+++ b/src/ApiRequestEditorElement.js
@@ -793,10 +793,6 @@ export class ApiRequestEditorElement extends AmfHelperMixin(EventsTargetMixin(Li
     });
 
     if (['GET', 'HEAD'].indexOf(result.method) === -1) {
-      const payload = this._payload
-      if (payload instanceof FormData) {
-        result.headers = /** @type string */ (HeadersParser.replace(result.headers, 'content-type', null));
-      }
       result.payload = this._payload;
     }
 

--- a/test/ApiRequestEditorElement.test.js
+++ b/test/ApiRequestEditorElement.test.js
@@ -1054,12 +1054,12 @@ describe('ApiRequestEditorElement', () => {
       element.url = 'some-url';
     });
 
-    it('should remove multipart content type if form data payload', () => {
+    it('should not remove multipart content type if form data payload', () => {
       element._headers = 'content-type: multipart/form-data';
       element._payload = new FormData()
       const request = element.serializeRequest()
 
-      assert.equal(request.headers, '');
+      assert.equal(request.headers, 'content-type: multipart/form-data');
     });
 
     it('should not modify headers if content type not defined and form data payload', () => {


### PR DESCRIPTION
When serializing request with a FormData payload, we're clearing the `Content-Type` header. It seems we included this as an old fix, but after some consideration it doesn't seem to make much sense to be doing this. If a user sets a header, whether by API spec or manually, we should respect them trying to send the request with that content type.