### PR TITLE
[W-14071465] Editing code while Console is opened changes the MS URL

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@api-components/api-request",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@api-components/api-request",
-      "version": "0.3.7",
+      "version": "0.3.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@advanced-rest-client/arc-events": "^0.2.13",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/api-request",
   "description": "A set of composite components that are used to build an HTTP request editor with the support of the AMF model.",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "license": "Apache-2.0",
   "main": "index.js",
   "module": "index.js",

--- a/src/ApiRequestEditorElement.js
+++ b/src/ApiRequestEditorElement.js
@@ -642,7 +642,7 @@ export class ApiRequestEditorElement extends AmfHelperMixin(
       let newOperationSelected = null;
 
       // loop throught a list of endpoints and find the operation with the same lexical value
-      endpoints.forEach((endpoint) => {
+      for (const endpoint of endpoints) {
         const supportedOperation = this._ensureArray(endpoint[opKey]);
         // if the operation is not supported by the endpoint, skip it
         if (!supportedOperation) {
@@ -657,7 +657,11 @@ export class ApiRequestEditorElement extends AmfHelperMixin(
             return lexicalValue === lexicalValueOld;
           });
         }
-      });
+        // if the operation is found, break the loop
+        if (newOperationSelected) {
+          break;
+        }
+      };
       // if the operation is not found, return the previous selection
       if (!newOperationSelected) {
         return this.selected;

--- a/src/ApiRequestPanelElement.js
+++ b/src/ApiRequestPanelElement.js
@@ -293,11 +293,11 @@ export class ApiRequestPanelElement extends EventsTargetMixin(LitElement) {
     this.allowCustomBaseUri = false;
     this.persistCache = false;
 
-    /**  
+    /**
      * @type {TransportRequest}
      */
     this.request = undefined;
-    /**  
+    /**
      * @type {ArcResponse|ErrorResponse}
      */
     this.response = undefined;
@@ -434,8 +434,8 @@ export class ApiRequestPanelElement extends EventsTargetMixin(LitElement) {
 
   /**
    * Propagate `api-response` detail object.
-   * 
-   * Until API Console v 6.x it was using a different response view. The current version 
+   *
+   * Until API Console v 6.x it was using a different response view. The current version
    * uses new response view based on ARC response view which uses different data structure.
    * This function transforms the response to the one of the corresponding data types used in ARC.
    * However, this keeps compatibility with previous versions of the transport library so it is


### PR DESCRIPTION
# Solution description:

When the AMF model changes, save the operation old and find this operation in the new AMF, then dispatch an event in the Api-console to set the newly selected shape.

Change in the [Api-Console](https://github.com/mulesoft/api-console/pull/839)

# Result: 
https://github.com/advanced-rest-client/api-request/assets/96145153/7d250822-3ba5-4679-a2ab-3a9bf006aa71

